### PR TITLE
[ITEP-70190] Fix: Prevent race conditions in NetVLAD model downloads

### DIFF
--- a/autocalibration/src/reloc/hloc/extractors/netvlad.py
+++ b/autocalibration/src/reloc/hloc/extractors/netvlad.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 import subprocess
 import logging
+import time
+import fcntl
+import os
 import numpy as np
 import torch
 import torch.nn as nn
@@ -15,6 +18,106 @@ logger = logging.getLogger(__name__)
 netvlad_path = Path(__file__).parent / '../../third_party/netvlad'
 
 EPS = 1e-6
+# Minimum file size for integrity checking (500MB for NetVLAD models)
+MIN_MODEL_SIZE_MB = 500
+
+def acquire_download_lock(lock_path: Path, timeout: int = 300):
+    try:
+        lock_file = open(lock_path, 'w')
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                logger.info("Acquired download lock")
+                return lock_file
+            except (IOError, OSError):
+                logger.info("Another process is downloading the model, waiting...")
+                time.sleep(1)
+        lock_file.close()
+        logger.error("Timeout waiting for download lock")
+        return None
+    except Exception as e:
+        logger.error(f"Error acquiring lock: {e}")
+        return None
+
+def release_download_lock(lock_file, lock_path: Path):
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        lock_file.close()
+        lock_path.unlink(missing_ok=True)
+        logger.info("Released download lock")
+    except Exception as e:
+        logger.warning(f"Error releasing lock: {e}")
+
+def check_model_integrity(checkpoint: Path) -> bool:
+    try:
+        if not checkpoint.exists():
+            return False
+        file_size = checkpoint.stat().st_size
+        min_size_bytes = MIN_MODEL_SIZE_MB * 1024 * 1024
+        if file_size < min_size_bytes:
+            logger.warning(f"Model file seems too small: {file_size} bytes (minimum expected: {min_size_bytes} bytes)")
+            return False
+        max_size_bytes = 2 * 1024 * 1024 * 1024  # 2GB
+        if file_size > max_size_bytes:
+            logger.warning(f"Model file seems too large: {file_size} bytes (maximum expected: {max_size_bytes} bytes)")
+            return False
+        logger.info(f"Model integrity check passed: {file_size} bytes")
+        return True
+    except Exception as e:
+        logger.error(f"Error checking model integrity: {e}")
+        return False
+
+def download_model_safely(checkpoint: Path, link: str) -> bool:
+    lock_path = checkpoint.with_suffix('.lock')
+    # First, check if we have a valid model
+    if checkpoint.exists() and check_model_integrity(checkpoint):
+        logger.info(f"NetVLAD model already exists and is valid at {checkpoint}")
+        return True
+    # Check for partial/corrupted file
+    if checkpoint.exists():
+        file_size = checkpoint.stat().st_size
+        min_size_bytes = MIN_MODEL_SIZE_MB * 1024 * 1024
+        if file_size < min_size_bytes:
+            logger.warning(f"Found partial/corrupted model file ({file_size} bytes), removing it")
+            checkpoint.unlink()
+        else:
+            logger.warning(f"Model file exists but failed integrity check, removing it")
+            checkpoint.unlink()
+    # Try to acquire download lock
+    lock_file = acquire_download_lock(lock_path)
+    if lock_file is None:
+        logger.info("Waiting for another process to complete download...")
+        max_wait = 300
+        start_time = time.time()
+        while time.time() - start_time < max_wait:
+            time.sleep(2)
+            if checkpoint.exists() and check_model_integrity(checkpoint):
+                logger.info("Model was downloaded by another process")
+                return True
+        logger.error("Timeout waiting for model download")
+        return False
+    try:
+        if checkpoint.exists() and check_model_integrity(checkpoint):
+            logger.info("Model was downloaded by another process while waiting for lock")
+            return True
+        checkpoint.parent.mkdir(exist_ok=True)
+        cmd = ['wget', link, '-O', str(checkpoint)]
+        logger.info(f'Downloading the NetVLAD model with `{cmd}`.')
+        try:
+            subprocess.run(cmd, check=True)
+            if check_model_integrity(checkpoint):
+                return True
+            else:
+                logger.error("Downloaded model failed integrity check")
+                checkpoint.unlink(missing_ok=True)
+                return False
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to download model: {e}")
+            checkpoint.unlink(missing_ok=True)
+            return False
+    finally:
+        release_download_lock(lock_file, lock_path)
 
 
 class NetVLADLayer(nn.Module):
@@ -60,14 +163,10 @@ class NetVLAD(BaseModel):
   def _init(self, conf):
     assert conf['model_name'] in self.dir_models.keys()
 
-    # Download the checkpoint.
     checkpoint = conf['checkpoint_dir'] / str(conf['model_name'] + '.mat')
-    if not checkpoint.exists():
-      checkpoint.parent.mkdir(exist_ok=True)
-      link = self.dir_models[conf['model_name']]
-      cmd = ['wget', link, '-O', str(checkpoint)]
-      logger.info(f'Downloading the NetVLAD model with `{cmd}`.')
-      subprocess.run(cmd, check=True)
+    link = self.dir_models[conf['model_name']]
+    if not download_model_safely(checkpoint, link):
+        raise RuntimeError(f"Failed to download NetVLAD model: {conf['model_name']}")
 
     # Create the network.
     # Remove classification head.

--- a/autocalibration/tools/ondemand_model_loader.py
+++ b/autocalibration/tools/ondemand_model_loader.py
@@ -2,10 +2,13 @@
 """
 On-demand NetVLAD model loader for SceneScape autocalibration.
 This script downloads the NetVLAD model only when needed, reducing Docker image size.
+Handles race conditions and partial downloads safely.
 """
 
 import os
 import sys
+import time
+import fcntl
 import requests
 import logging
 from pathlib import Path
@@ -28,6 +31,39 @@ def get_model_path() -> Path:
   model_dir.mkdir(parents=True, exist_ok=True)
   return model_dir / NETVLAD_MODEL_NAME
 
+def get_lock_path() -> Path:
+  model_dir = Path(MODEL_DIR)
+  model_dir.mkdir(parents=True, exist_ok=True)
+  return model_dir / f"{NETVLAD_MODEL_NAME}.lock"
+
+def acquire_download_lock(lock_path: Path, timeout: int = 300) -> Optional[object]:
+  try:
+    lock_file = open(lock_path, 'w')
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+      try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        logger.info("Acquired download lock")
+        return lock_file
+      except (IOError, OSError):
+        logger.info("Another process is downloading the model, waiting...")
+        time.sleep(1)
+    lock_file.close()
+    logger.error("Timeout waiting for download lock")
+    return None
+  except Exception as e:
+    logger.error(f"Error acquiring lock: {e}")
+    return None
+
+def release_download_lock(lock_file: object, lock_path: Path):
+  try:
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    lock_file.close()
+    lock_path.unlink(missing_ok=True)
+    logger.info("Released download lock")
+  except Exception as e:
+    logger.warning(f"Error releasing lock: {e}")
+
 def download_file(url: str, destination: Path, chunk_size: int = 8192) -> bool:
   """
   Download file with progress bar and error handling.
@@ -47,8 +83,9 @@ def download_file(url: str, destination: Path, chunk_size: int = 8192) -> bool:
 
     total_size = int(response.headers.get('content-length', 0))
     downloaded = 0
+    temp_destination = destination.with_suffix('.tmp')
 
-    with open(destination, 'wb') as f:
+    with open(temp_destination, 'wb') as f:
       for chunk in response.iter_content(chunk_size=chunk_size):
         if chunk:
           f.write(chunk)
@@ -61,14 +98,21 @@ def download_file(url: str, destination: Path, chunk_size: int = 8192) -> bool:
             sys.stdout.flush()
 
     print()  # New line after progress
+    if total_size > 0 and downloaded != total_size:
+      logger.error(f"Download incomplete: {downloaded}/{total_size} bytes")
+      temp_destination.unlink(missing_ok=True)
+      return False
+    temp_destination.rename(destination)
     logger.info(f"Download complete: {destination}")
     return True
 
   except requests.exceptions.RequestException as e:
     logger.error(f"Failed to download model: {e}")
+    temp_destination.unlink(missing_ok=True)
     return False
   except Exception as e:
     logger.error(f"Unexpected error during download: {e}")
+    temp_destination.unlink(missing_ok=True)
     return False
 
 def ensure_model_exists() -> Optional[Path]:
@@ -79,19 +123,51 @@ def ensure_model_exists() -> Optional[Path]:
     Path to the model file if successful, None otherwise
   """
   model_path = get_model_path()
-
-  # Check if model already exists
+  lock_path = get_lock_path()
+  # First, check if we have a valid model
+  if model_path.exists() and check_model_integrity(model_path):
+    logger.info(f"NetVLAD model already exists and is valid at {model_path}")
+    return model_path
+  # Check for partial/corrupted file
   if model_path.exists():
-    logger.info(f"NetVLAD model already exists at {model_path}")
-    return model_path
-
-  # Download the model
-  logger.info(f"NetVLAD model not found. Starting download...")
-  if download_file(NETVLAD_MODEL_URL, model_path):
-    return model_path
-  else:
-    logger.error("Failed to download NetVLAD model")
+    file_size = model_path.stat().st_size
+    min_size_bytes = NETVLAD_MODEL_MIN_SIZE_MB * 1024 * 1024
+    if file_size < min_size_bytes:
+      logger.warning(f"Found partial/corrupted model file ({file_size} bytes), removing it")
+      model_path.unlink()
+    else:
+      logger.warning(f"Model file exists but failed integrity check, removing it")
+      model_path.unlink()
+  # Try to acquire download lock
+  lock_file = acquire_download_lock(lock_path)
+  if lock_file is None:
+    logger.info("Waiting for another process to complete download...")
+    max_wait = 300
+    start_time = time.time()
+    while time.time() - start_time < max_wait:
+      time.sleep(2)
+      if model_path.exists() and check_model_integrity(model_path):
+        logger.info("Model was downloaded by another process")
+        return model_path
+    logger.error("Timeout waiting for model download")
     return None
+  try:
+    if model_path.exists() and check_model_integrity(model_path):
+      logger.info("Model was downloaded by another process while waiting for lock")
+      return model_path
+    logger.info(f"NetVLAD model not found. Starting download...")
+    if download_file(NETVLAD_MODEL_URL, model_path):
+      if check_model_integrity(model_path):
+        return model_path
+      else:
+        logger.error("Downloaded model failed integrity check")
+        model_path.unlink(missing_ok=True)
+        return None
+    else:
+      logger.error("Failed to download NetVLAD model")
+      return None
+  finally:
+    release_download_lock(lock_file, lock_path)
 
 def check_model_integrity(model_path: Path) -> bool:
   """
@@ -127,10 +203,6 @@ def main():
   model_path = ensure_model_exists()
   if model_path is None:
     logger.error("Failed to ensure model exists")
-    sys.exit(1)
-
-  if not check_model_integrity(model_path):
-    logger.error("Model integrity check failed")
     sys.exit(1)
 
   logger.info("NetVLAD model is ready for use")


### PR DESCRIPTION
## 📝 Description

When multiple camcalibration containers start simultaneously (e.g., during docker compose up), they can interfere with each other's NetVLAD model downloads, leading to partial/corrupted files and infinite error loops.

<!--
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: ITEP-70190

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Ran automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works